### PR TITLE
Introduce EI_MODEL env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "edge-impulse-ffi-rs"
 version = "0.1.0"
-source = "git+https://github.com/edgeimpulse/edge-impulse-ffi-rs.git#cc8ee2518d0a52b6f98f08509177c5098f805d83"
+source = "git+https://github.com/edgeimpulse/edge-impulse-ffi-rs.git#79a2f0ae7618a73256956b843b6e2264ba752ffe"
 dependencies = [
  "bindgen",
  "cc",

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
     println!("cargo:info=Runner build script starting...");
@@ -9,45 +10,80 @@ fn main() {
     println!("cargo:info=FFI feature enabled: {ffi_enabled}");
 
     if ffi_enabled {
-        println!("cargo:info=FFI feature enabled, checking required environment variables...");
+        println!("cargo:info=FFI feature enabled, checking for model files...");
 
-        // Check for required environment variables
-        let project_id = env::var("EI_PROJECT_ID");
-        let api_key = env::var("EI_API_KEY");
+        // Check if model files exist in the edge-impulse-ffi-rs dependency
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+        let ffi_dep_path = Path::new(&manifest_dir).join("edge-impulse-ffi-rs");
 
-        match (project_id, api_key) {
-            (Ok(project_id), Ok(api_key)) => {
-                println!("cargo:info=Found EI_PROJECT_ID: {project_id}");
-                println!(
-                    "cargo:info=Found EI_API_KEY: {}...",
-                    &api_key[..api_key.len().min(8)]
-                );
-                println!("cargo:info=Environment variables are set correctly for FFI mode");
-            }
-            (Err(_), Err(_)) => {
-                eprintln!(
-                    "cargo:error=FFI mode requires EI_PROJECT_ID and EI_API_KEY environment variables to be set"
-                );
-                eprintln!("cargo:error=Please set these variables before building:");
-                eprintln!("cargo:error=  export EI_PROJECT_ID=your_project_id");
-                eprintln!("cargo:error=  export EI_API_KEY=your_api_key");
-                std::process::exit(1);
-            }
-            (Err(_), _) => {
-                eprintln!(
-                    "cargo:error=FFI mode requires EI_PROJECT_ID environment variable to be set"
-                );
-                eprintln!("cargo:error=Please set this variable before building:");
-                eprintln!("cargo:error=  export EI_PROJECT_ID=your_project_id");
-                std::process::exit(1);
-            }
-            (_, Err(_)) => {
-                eprintln!(
-                    "cargo:error=FFI mode requires EI_API_KEY environment variable to be set"
-                );
-                eprintln!("cargo:error=Please set this variable before building:");
-                eprintln!("cargo:error=  export EI_API_KEY=your_api_key");
-                std::process::exit(1);
+        // Check for essential model components
+        let sdk_dir = ffi_dep_path.join("model/edge-impulse-sdk");
+        let model_parameters_dir = ffi_dep_path.join("model/model-parameters");
+        let tflite_model_dir = ffi_dep_path.join("model/tflite-model");
+
+        let has_valid_model = sdk_dir.exists() && model_parameters_dir.exists() && tflite_model_dir.exists();
+
+        if has_valid_model {
+            println!("cargo:info=Found valid model files in edge-impulse-ffi-rs dependency");
+            println!("cargo:info=No environment variables required for FFI mode");
+        } else {
+            println!("cargo:info=No valid model files found, checking for environment variables...");
+
+            // Check for EI_MODEL environment variable first
+            if let Ok(model_path) = env::var("EI_MODEL") {
+                println!("cargo:info=Found EI_MODEL environment variable: {}", model_path);
+                println!("cargo:info=The edge-impulse-ffi-rs dependency will handle copying from this path");
+            } else {
+                println!("cargo:info=No EI_MODEL environment variable found, checking for API credentials...");
+
+                // Check for required environment variables
+                let project_id = env::var("EI_PROJECT_ID");
+                let api_key = env::var("EI_API_KEY");
+
+                match (project_id, api_key) {
+                    (Ok(project_id), Ok(api_key)) => {
+                        println!("cargo:info=Found EI_PROJECT_ID: {project_id}");
+                        println!(
+                            "cargo:info=Found EI_API_KEY: {}...",
+                            &api_key[..api_key.len().min(8)]
+                        );
+                        println!("cargo:info=Environment variables are set correctly for FFI mode");
+                    }
+                    (Err(_), Err(_)) => {
+                        eprintln!(
+                            "cargo:error=FFI mode requires environment variables to provide model files"
+                        );
+                        eprintln!("cargo:error=Please either:");
+                        eprintln!("cargo:error=  1. Set EI_MODEL environment variable:");
+                        eprintln!("cargo:error=     export EI_MODEL=/path/to/your/model");
+                        eprintln!("cargo:error=  2. Set API environment variables:");
+                        eprintln!("cargo:error=     export EI_PROJECT_ID=your_project_id");
+                        eprintln!("cargo:error=     export EI_API_KEY=your_api_key");
+                        std::process::exit(1);
+                    }
+                    (Err(_), _) => {
+                        eprintln!(
+                            "cargo:error=FFI mode requires environment variables to provide model files"
+                        );
+                        eprintln!("cargo:error=Please either:");
+                        eprintln!("cargo:error=  1. Set EI_MODEL environment variable:");
+                        eprintln!("cargo:error=     export EI_MODEL=/path/to/your/model");
+                        eprintln!("cargo:error=  2. Set EI_PROJECT_ID environment variable:");
+                        eprintln!("cargo:error=     export EI_PROJECT_ID=your_project_id");
+                        std::process::exit(1);
+                    }
+                    (_, Err(_)) => {
+                        eprintln!(
+                            "cargo:error=FFI mode requires environment variables to provide model files"
+                        );
+                        eprintln!("cargo:error=Please either:");
+                        eprintln!("cargo:error=  1. Set EI_MODEL environment variable:");
+                        eprintln!("cargo:error=     export EI_MODEL=/path/to/your/model");
+                        eprintln!("cargo:error=  2. Set EI_API_KEY environment variable:");
+                        eprintln!("cargo:error=     export EI_API_KEY=your_api_key");
+                        std::process::exit(1);
+                    }
+                }
             }
         }
     } else {

--- a/build.rs
+++ b/build.rs
@@ -21,20 +21,27 @@ fn main() {
         let model_parameters_dir = ffi_dep_path.join("model/model-parameters");
         let tflite_model_dir = ffi_dep_path.join("model/tflite-model");
 
-        let has_valid_model = sdk_dir.exists() && model_parameters_dir.exists() && tflite_model_dir.exists();
+        let has_valid_model =
+            sdk_dir.exists() && model_parameters_dir.exists() && tflite_model_dir.exists();
 
         if has_valid_model {
             println!("cargo:info=Found valid model files in edge-impulse-ffi-rs dependency");
             println!("cargo:info=No environment variables required for FFI mode");
         } else {
-            println!("cargo:info=No valid model files found, checking for environment variables...");
+            println!(
+                "cargo:info=No valid model files found, checking for environment variables..."
+            );
 
             // Check for EI_MODEL environment variable first
             if let Ok(model_path) = env::var("EI_MODEL") {
-                println!("cargo:info=Found EI_MODEL environment variable: {}", model_path);
-                println!("cargo:info=The edge-impulse-ffi-rs dependency will handle copying from this path");
+                println!("cargo:info=Found EI_MODEL environment variable: {model_path}");
+                println!(
+                    "cargo:info=The edge-impulse-ffi-rs dependency will handle copying from this path"
+                );
             } else {
-                println!("cargo:info=No EI_MODEL environment variable found, checking for API credentials...");
+                println!(
+                    "cargo:info=No EI_MODEL environment variable found, checking for API credentials..."
+                );
 
                 // Check for required environment variables
                 let project_id = env::var("EI_PROJECT_ID");

--- a/examples/video_infer.rs
+++ b/examples/video_infer.rs
@@ -105,19 +105,41 @@ impl PerformanceMetrics {
             Duration::ZERO
         };
 
-        let min_inference_time = self.inference_samples.iter().min().unwrap_or(&Duration::ZERO);
-        let max_inference_time = self.inference_samples.iter().max().unwrap_or(&Duration::ZERO);
+        let min_inference_time = self
+            .inference_samples
+            .iter()
+            .min()
+            .unwrap_or(&Duration::ZERO);
+        let max_inference_time = self
+            .inference_samples
+            .iter()
+            .max()
+            .unwrap_or(&Duration::ZERO);
 
         println!("\n📊 PERFORMANCE SUMMARY:");
         println!("   Total frames processed: {}", self.frame_count);
         println!("   Total runtime: {:.2}s", total_time.as_secs_f64());
         println!("   Average FPS: {:.2}", avg_fps);
-        println!("   Average inference time: {:.2}ms", avg_inference_time.as_millis());
-        println!("   Min inference time: {:.2}ms", min_inference_time.as_millis());
-        println!("   Max inference time: {:.2}ms", max_inference_time.as_millis());
-        println!("   Total inference time: {:.2}s", self.total_inference_time.as_secs_f64());
-        println!("   Inference efficiency: {:.1}%",
-            (self.total_inference_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0);
+        println!(
+            "   Average inference time: {:.2}ms",
+            avg_inference_time.as_millis()
+        );
+        println!(
+            "   Min inference time: {:.2}ms",
+            min_inference_time.as_millis()
+        );
+        println!(
+            "   Max inference time: {:.2}ms",
+            max_inference_time.as_millis()
+        );
+        println!(
+            "   Total inference time: {:.2}s",
+            self.total_inference_time.as_secs_f64()
+        );
+        println!(
+            "   Inference efficiency: {:.1}%",
+            (self.total_inference_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0
+        );
     }
 }
 


### PR DESCRIPTION
This PR introduces the `EI_MODEL` environment variable to provide a more flexible way to source Edge Impulse models during the build process, eliminating the need for API credentials in many scenarios.
