### PR TITLE
Pin rust image at 1.90.0-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:1.90.0-bookworm
 
 # Install cross-compilation tools and dependencies
 RUN dpkg --add-architecture arm64 && \


### PR DESCRIPTION
Closes #21 

Pinning image version to `rust:1.90.0-bookworm` resolves all dependency installation issues